### PR TITLE
Implement: add 1 simple typescript with react examples under a new dir called frameworks, no need to test it or anything, just a quick simple example, be quick.

### DIFF
--- a/claude-logs.txt
+++ b/claude-logs.txt
@@ -1,0 +1,41 @@
+=== Claude Agent Log Session Started ===
+Job ID: k177ptczm5jqapdzbhz1czmxn17kgdgp
+Workspace: /home/daytona/workspace
+Started: 2025-07-11T06:58:28.362842
+==================================================
+
+[2025-07-11 06:58:28] [INFO] Stream file initialized at /home/daytona/workspace/claude_agent_stream.jsonl
+[2025-07-11 06:58:28] [INFO] Working on repository: /home/daytona/workspace
+[2025-07-11 06:58:28] [INFO] Task: add 1 simple typescript with react examples under a new dir called frameworks, no need to test it or anything, just a quick simple example, be quick.
+[2025-07-11 06:58:28] [INFO] Validating repository path...
+[2025-07-11 06:58:28] [INFO] Repository path validated
+[2025-07-11 06:58:28] [INFO] Starting Claude Code execution...
+[2025-07-11 06:58:28] [DEBUG] About to enter async loop
+[2025-07-11 06:58:28] [INFO] Claude Code analysis started
+[2025-07-11 06:58:28] [INFO] Agent step emitted: analysis_start - Claude Code analysis started
+    Metadata: {
+  "metadata": null
+}
+[2025-07-11 06:58:28] [INFO] Agent step JSON output: [AGENT_STEP_JSON]{"timestamp": "2025-07-11T06:58:28.921023", "type": "analysis_start", "message": "Claude Code analysis started", "job_id": "k177ptczm5jqapdzbhz1czmxn17kgdgp"}[/AGENT_STEP_JSON]
+[2025-07-11 06:58:29] [DEBUG] Claude thinking: Invalid API key · Fix external API key
+[2025-07-11 06:58:29] [INFO] Agent step emitted: thinking - Thinking: Invalid API key · Fix external API key
+    Metadata: {
+  "metadata": {
+    "full_text": "Invalid API key \u00b7 Fix external API key"
+  }
+}
+[2025-07-11 06:58:29] [INFO] Agent step JSON output: [AGENT_STEP_JSON]{"timestamp": "2025-07-11T06:58:29.876536", "type": "thinking", "message": "Thinking: Invalid API key \u00b7 Fix external API key", "job_id": "k177ptczm5jqapdzbhz1czmxn17kgdgp", "metadata": {"full_text": "Invalid API key \u00b7 Fix external API key"}}[/AGENT_STEP_JSON]
+[2025-07-11 06:58:29] [ERROR] Task failed: Invalid API key · Fix external API key
+[2025-07-11 06:58:29] [INFO] Agent step emitted: error - Task failed: Invalid API key · Fix external API key
+    Metadata: {
+  "metadata": null
+}
+[2025-07-11 06:58:29] [INFO] Agent step JSON output: [AGENT_STEP_JSON]{"timestamp": "2025-07-11T06:58:29.876774", "type": "error", "message": "Task failed: Invalid API key \u00b7 Fix external API key", "job_id": "k177ptczm5jqapdzbhz1czmxn17kgdgp"}[/AGENT_STEP_JSON]
+[2025-07-11 06:58:29] [DEBUG] Exited async loop
+[2025-07-11 06:58:29] [INFO] Completed processing 3 messages
+[2025-07-11 06:58:29] [INFO] Task execution completed successfully
+[2025-07-11 06:58:29] [INFO] Agent step emitted: claude_complete - Claude code implementation completed
+    Metadata: {
+  "metadata": null
+}
+[2025-07-11 06:58:29] [INFO] Agent step JSON output: [AGENT_STEP_JSON]{"timestamp": "2025-07-11T06:58:29.889589", "type": "claude_complete", "message": "Claude code implementation completed", "job_id": "k177ptczm5jqapdzbhz1czmxn17kgdgp"}[/AGENT_STEP_JSON]


### PR DESCRIPTION
This PR implements the requested changes:

add 1 simple typescript with react examples under a new dir called frameworks, no need to test it or anything, just a quick simple example, be quick.

Implemented by Claude Code agent with unified workflow streaming.